### PR TITLE
Update scanfolder.sh

### DIFF
--- a/scanfolder.sh
+++ b/scanfolder.sh
@@ -7,6 +7,31 @@ USERPASS=$5
 INPUT="/opt/scanfolder/section-$TRIGGER-${SOURCE_FOLDER///}-folders.txt"
 DOCKERNAME="plex"
 
+check_each_item ()
+{
+         fullfile=$CONTAINER_FOLDER$f2
+         filename=$(basename -- "$fullfile")
+         fullfile=$(printf "%s" "$fullfile" | sed 's|[\]||g')
+         fullfile=$(printf "%s" "$fullfile" | sed "s/'/\"/g")
+         #extension="${filename##*.}"
+         #filename="${filename%.*}"
+         cmd="select file from media_parts where file like '$fullfile%'"
+         IFS=$'\n'
+         fqry=(`sqlite3 /opt/plex/Library/Application\ Support/Plex\ Media\ Server/Plug-in\ Support/Databases/com.plexapp.plugins.library.db "$cmd"`)
+
+         for f in "${fqry[@]}"; do
+           echo "$f"
+           count="$( find "$f" -type f \( -iname \*.mkv -o -iname \*.mpeg -o -iname \*.m2ts -o -iname \*.ts -o -iname \*.avi -o -iname \*.mp4 -o -iname \*.m4v -o -iname \*.asf -o -iname \*.mov $
+           if test $count -eq 1; then
+                echo "individual file names the same, no update"
+           else
+                echo "update media"
+                h=$(printf %q "$f1")
+                echo $h >> $INPUT
+           fi
+         done
+}
+
 get_folders () {
 
 for f in "$SOURCE_FOLDER"/*; do
@@ -27,6 +52,8 @@ for f in "$SOURCE_FOLDER"/*; do
              linecount="$( find ./"$f2" -type f \( -iname \*.mkv -o -iname \*.mpeg -o -iname \*.m2ts -o -iname \*.ts -o -iname \*.avi -o -iname \*.mp4 -o -iname \*.m4v -o -iname \*.asf -o -iname \*.mov -o -iname \*.mpegts -o -iname \*.vob -o -iname \*.divx -o -iname \*.wmv \) | wc -l )"
 	if test $linecount -eq $exists; then
                 echo "item count the same"
+		#check all items to see if text matches
+                check_each_item 
              else
                 echo "update media"
                 h=$(printf %q "$f1")


### PR DESCRIPTION
Added a new check -
After it is determined the item count matches, 
autoscan will then check each file name for that media type (movie or TV) and make sure the file names match.
This is useful for when media is upgrade, the media count won't change.  So this check will find this type of change