### PR TITLE
epoch time Fix

### DIFF
--- a/scanfolder.sh
+++ b/scanfolder.sh
@@ -81,11 +81,16 @@ get_files ()
      FOO=$(basename "${i}")     
      FOO="$(echo -e "${FOO}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
      FOO=${#FOO}  
+     d1=${FOO##*|}
+     echo "${d1}"
+     d1=$(date -d "${d1}" +%s)
+     echo "${d1}"
      F2=1
      if [ "$FOO" -gt "$F2" ]; then        
         file_list+=("${CONTAINER_FOLDER}${SOURCE_FOLDER}${i}")
      fi
   done
+  exit
 }
 
 get_db_items ()

--- a/scanfolder.sh
+++ b/scanfolder.sh
@@ -75,22 +75,21 @@ get_files ()
     filelist=($(rclone lsf --files-only --absolute --max-depth "$depth" --format pt --separator "|" "$RCLONEMOUNT:$ZDTD/$SOURCE_FOLDER"))
     unset IFS
   fi
-  file_list=()
   for i in "${filelist[@]}"
   do
      FOO=$(basename "${i}")     
      FOO="$(echo -e "${FOO}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
      FOO=${#FOO}  
-     d1=${FOO##*|}
-     echo "${d1}"
+     d1=${i##*|}
      d1=$(date -d "${d1}" +%s)
-     echo "${d1}"
+     i2=${i%|*} 
      F2=1
-     if [ "$FOO" -gt "$F2" ]; then        
-        file_list+=("${CONTAINER_FOLDER}${SOURCE_FOLDER}${i}")
+     if [ "$FOO" -gt "$F2" ]; then
+        if [[ ! "${i2}" =~ ".nfo" ]]; then
+           file_list+=("${CONTAINER_FOLDER}${SOURCE_FOLDER}${i2}|${d2}")
+        fi
      fi
   done
-  exit
 }
 
 get_db_items ()
@@ -107,7 +106,10 @@ get_db_items ()
          fqry=(`sqlite3 "$plex" "$cmd"`)
          unset IFS
          for f in "${fqry[@]}"; do
-           db_list+=("${f}")
+           d1=${f##*|}
+           d1=$(date -d "${d1}" +%s)
+           f2=${f%|*} 
+           db_list+=("${f2}|${d2}")
          done
 }
 


### PR DESCRIPTION
the comparison of the `rclone lsf` and the plex.db is much better now
before the two are compared the DateTime stamp for both strings are converted to epoch time.

additionally, the `rclone lsf` result excludes .nfo files from the array